### PR TITLE
ISSUE-18 JPA 엔티티 설계

### DIFF
--- a/domain/src/main/kotlin/org/doorip/domain/trip/TodoType.kt
+++ b/domain/src/main/kotlin/org/doorip/domain/trip/TodoType.kt
@@ -3,7 +3,7 @@ package org.doorip.domain.trip
 enum class TodoType(
     private val description: String,
 ) {
-    OUR_TODO("아워 투두"),
-    MY_TODO("마이 투두"),
+    OUR("아워 투두"),
+    MY("마이 투두"),
     ;
 }

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/auth/AccessTokenGateway.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/auth/AccessTokenGateway.kt
@@ -1,4 +1,4 @@
-package org.doorip.gateway.rdb.token
+package org.doorip.gateway.rdb.auth
 
 import java.time.LocalDateTime
 import java.time.temporal.TemporalAmount

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/auth/RefreshTokenGateway.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/auth/RefreshTokenGateway.kt
@@ -1,4 +1,4 @@
-package org.doorip.gateway.rdb.token
+package org.doorip.gateway.rdb.auth
 
 import java.security.SecureRandom
 import java.time.LocalDateTime

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/auth/RefreshTokenJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/auth/RefreshTokenJpaEntity.kt
@@ -1,4 +1,4 @@
-package org.doorip.gateway.rdb.token
+package org.doorip.gateway.rdb.auth
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/auth/RefreshTokenJpaRepository.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/auth/RefreshTokenJpaRepository.kt
@@ -1,4 +1,4 @@
-package org.doorip.gateway.rdb.token
+package org.doorip.gateway.rdb.auth
 
 import org.doorip.domain.user.UserId
 import org.springframework.data.jpa.repository.JpaRepository

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/AllocatorJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/AllocatorJpaEntity.kt
@@ -1,0 +1,18 @@
+package org.doorip.gateway.rdb.trip
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Table(name = "allocator")
+@Entity
+internal class AllocatorJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "allocator_id", columnDefinition = "bigint", nullable = false)
+    var id: Long = 0
+        protected set
+}

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/AllocatorJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/AllocatorJpaEntity.kt
@@ -2,9 +2,12 @@ package org.doorip.gateway.rdb.trip
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Table(name = "allocator")
@@ -14,5 +17,15 @@ internal class AllocatorJpaEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "allocator_id", columnDefinition = "bigint", nullable = false)
     var id: Long = 0
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id")
+    lateinit var participant: ParticipantJpaEntity
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "todo_id")
+    lateinit var todo: TodoJpaEntity
         protected set
 }

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/ParticipantJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/ParticipantJpaEntity.kt
@@ -3,11 +3,18 @@ package org.doorip.gateway.rdb.trip
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.doorip.domain.trip.PropensityTag
+import org.doorip.gateway.rdb.user.UserJpaEntity
+import org.hibernate.annotations.Cascade
+import org.hibernate.annotations.CascadeType
 
 @Table(name = "participant")
 @Entity
@@ -21,4 +28,18 @@ internal class ParticipantJpaEntity {
     @Embedded
     lateinit var propensityTag: PropensityTag
         protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    lateinit var user: UserJpaEntity
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    lateinit var trip: TripJpaEntity
+        protected set
+
+    @Cascade(CascadeType.REMOVE)
+    @OneToMany(mappedBy = "participant")
+    val allocators: MutableList<AllocatorJpaEntity> = mutableListOf()
 }

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/ParticipantJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/ParticipantJpaEntity.kt
@@ -1,0 +1,24 @@
+package org.doorip.gateway.rdb.trip
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.doorip.domain.trip.PropensityTag
+
+@Table(name = "participant")
+@Entity
+internal class ParticipantJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "participant_id", columnDefinition = "bigint", nullable = false)
+    var id: Long = 0
+        protected set
+
+    @Embedded
+    lateinit var propensityTag: PropensityTag
+        protected set
+}

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/PropensityTag.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/PropensityTag.kt
@@ -1,0 +1,18 @@
+package org.doorip.gateway.rdb.trip
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+
+@Embeddable
+data class PropensityTag(
+    @Column(name = "style_a", columnDefinition = "integer")
+    val styleA: Int,
+    @Column(name = "style_b", columnDefinition = "integer")
+    val styleB: Int,
+    @Column(name = "style_c", columnDefinition = "integer")
+    val styleC: Int,
+    @Column(name = "style_d", columnDefinition = "integer")
+    val styleD: Int,
+    @Column(name = "style_e", columnDefinition = "integer")
+    val styleE: Int,
+)

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TodoJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TodoJpaEntity.kt
@@ -4,13 +4,19 @@ import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import java.time.LocalDate
 import org.doorip.domain.trip.TodoStatus
 import org.doorip.domain.trip.TodoType
+import org.hibernate.annotations.Cascade
+import org.hibernate.annotations.CascadeType
 
 @Table(name = "todo")
 @Entity
@@ -42,4 +48,13 @@ internal class TodoJpaEntity {
     @Column(name = "progress", columnDefinition = "enum('incomplete', 'complete')", nullable = false)
     lateinit var todoStatus: TodoStatus
         protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    lateinit var trip: TripJpaEntity
+        protected set
+
+    @Cascade(value = [CascadeType.PERSIST, CascadeType.REMOVE])
+    @OneToMany(mappedBy = "todo")
+    val allocators: MutableList<AllocatorJpaEntity> = mutableListOf()
 }

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TodoJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TodoJpaEntity.kt
@@ -1,0 +1,45 @@
+package org.doorip.gateway.rdb.trip
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+import org.doorip.domain.trip.TodoStatus
+import org.doorip.domain.trip.TodoType
+
+@Table(name = "todo")
+@Entity
+internal class TodoJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "todo_id", columnDefinition = "bigint", nullable = false)
+    var id: Long = 0
+        protected set
+
+    @Column(name = "title", columnDefinition = "varchar(255)", nullable = false)
+    lateinit var title: String
+        protected set
+
+    @Column(name = "end_date", columnDefinition = "date", nullable = false)
+    lateinit var endDate: LocalDate
+        protected set
+
+    @Column(name = "memo", columnDefinition = "text", nullable = true)
+    var memo: String? = null
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "secret", columnDefinition = "enum('OUR', 'MY')", nullable = false)
+    lateinit var todoType: TodoType
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "progress", columnDefinition = "enum('incomplete', 'complete')", nullable = false)
+    lateinit var todoStatus: TodoStatus
+        protected set
+}

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TripJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TripJpaEntity.kt
@@ -5,8 +5,11 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import java.time.LocalDate
+import org.hibernate.annotations.Cascade
+import org.hibernate.annotations.CascadeType
 
 @Table(name = "trip")
 @Entity
@@ -32,4 +35,12 @@ internal class TripJpaEntity {
     @Column(name = "end_date", columnDefinition = "date", nullable = false)
     lateinit var endDate: LocalDate
         protected set
+
+    @Cascade(value = [CascadeType.PERSIST, CascadeType.REMOVE])
+    @OneToMany(mappedBy = "trip")
+    val participants: MutableList<ParticipantJpaEntity> = mutableListOf()
+
+    @Cascade(CascadeType.REMOVE)
+    @OneToMany(mappedBy = "trip")
+    val todos: MutableList<TodoJpaEntity> = mutableListOf()
 }

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TripJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TripJpaEntity.kt
@@ -1,0 +1,35 @@
+package org.doorip.gateway.rdb.trip
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+
+@Table(name = "trip")
+@Entity
+internal class TripJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "trip_id", columnDefinition = "bigint", nullable = false)
+    var id: Long = 0
+        protected set
+
+    @Column(name = "code", columnDefinition = "varchar(255)", nullable = false)
+    lateinit var code: String
+        protected set
+
+    @Column(name = "title", columnDefinition = "varchar(255)", nullable = false)
+    lateinit var title: String
+        protected set
+
+    @Column(name = "start_date", columnDefinition = "date", nullable = false)
+    lateinit var startDate: LocalDate
+        protected set
+
+    @Column(name = "end_date", columnDefinition = "date", nullable = false)
+    lateinit var endDate: LocalDate
+        protected set
+}

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/user/UserJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/user/UserJpaEntity.kt
@@ -19,7 +19,7 @@ internal class UserJpaEntity : BaseJpaEntity() {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "user_id")
+    @Column(name = "user_id", columnDefinition = "bigint", nullable = false)
     var id: Long = 0
         protected set
 
@@ -31,7 +31,7 @@ internal class UserJpaEntity : BaseJpaEntity() {
     lateinit var intro: String
         protected set
 
-    @Column(name = "result", columnDefinition = "integer")
+    @Column(name = "result", columnDefinition = "integer", nullable = true)
     var result: Int? = null
 
     @Enumerated(EnumType.STRING)

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/user/UserJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/user/UserJpaEntity.kt
@@ -16,7 +16,6 @@ import org.doorip.gateway.rdb.BaseJpaEntity
 @Table(name = "users")
 @Entity
 internal class UserJpaEntity : BaseJpaEntity() {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id", columnDefinition = "bigint", nullable = false)


### PR DESCRIPTION
### Related Issue ✔
close #18 

### Description ✔


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩토링**
	- `TodoType` 열거형의 상수 이름을 간결하게 변경 (`OUR_TODO` → `OUR`, `MY_TODO` → `MY`)
	- 토큰 관련 클래스의 패키지를 `token`에서 `auth`로 재구성

- **새로운 기능**
	- 여행 관련 데이터베이스 엔티티 추가
		- `AllocatorJpaEntity`
		- `ParticipantJpaEntity`
		- `PropensityTag`
		- `TodoJpaEntity`
		- `TripJpaEntity`

- **버그 수정**
	- `UserJpaEntity`의 열 정의 명확화 및 null 제약 조건 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->