### PR TITLE
ISSUE-26 여행 대시보드 전체 조회 API 개발

### DIFF
--- a/core/src/main/kotlin/org/doorip/core/trip/TripService.kt
+++ b/core/src/main/kotlin/org/doorip/core/trip/TripService.kt
@@ -3,6 +3,7 @@ package org.doorip.core.trip
 import java.time.LocalDate
 import org.doorip.domain.TripNotFoundException
 import org.doorip.domain.UserNotFoundException
+import org.doorip.domain.trip.Progress
 import org.doorip.domain.trip.PropensityTag
 import org.doorip.domain.trip.Trip
 import org.doorip.domain.trip.TripId
@@ -50,5 +51,9 @@ internal class TripService(
         )
 
         return tripId
+    }
+
+    override fun getTrips(userId: UserId, progress: Progress): List<Trip> {
+        return tripRepository.getTrips(userId, progress)
     }
 }

--- a/core/src/main/kotlin/org/doorip/core/trip/TripUseCase.kt
+++ b/core/src/main/kotlin/org/doorip/core/trip/TripUseCase.kt
@@ -1,6 +1,7 @@
 package org.doorip.core.trip
 
 import java.time.LocalDate
+import org.doorip.domain.trip.Progress
 import org.doorip.domain.trip.PropensityTag
 import org.doorip.domain.trip.Trip
 import org.doorip.domain.trip.TripId
@@ -10,4 +11,5 @@ interface TripUseCase {
     fun createTrip(userId: UserId, title: String, startAt: LocalDate, endAt: LocalDate, styles: PropensityTag): Trip
     fun verifyInvitationCode(code: String): Trip
     fun entryTrip(userId: UserId, tripId: TripId, styles: PropensityTag): TripId
+    fun getTrips(userId: UserId, progress: Progress): List<Trip>
 }

--- a/domain/src/main/kotlin/org/doorip/domain/trip/Progress.kt
+++ b/domain/src/main/kotlin/org/doorip/domain/trip/Progress.kt
@@ -1,0 +1,15 @@
+package org.doorip.domain.trip
+
+enum class Progress(
+    private val description: String,
+) {
+    INCOMPLETE("incomplete"),
+    COMPLETE("complete"),
+    ;
+
+    companion object {
+        fun getProgress(description: String): Progress? {
+            return entries.find { it.description == description }
+        }
+    }
+}

--- a/domain/src/main/kotlin/org/doorip/domain/trip/Trip.kt
+++ b/domain/src/main/kotlin/org/doorip/domain/trip/Trip.kt
@@ -13,5 +13,4 @@ data class Trip(
     val title: String,
     val startAt: LocalDate,
     val endAt: LocalDate,
-    val participants: List<Participant>,
 )

--- a/domain/src/main/kotlin/org/doorip/domain/trip/TripRepository.kt
+++ b/domain/src/main/kotlin/org/doorip/domain/trip/TripRepository.kt
@@ -9,4 +9,5 @@ interface TripRepository {
     fun entryTrip(userId: UserId, tripId: TripId, styles: PropensityTag)
     fun getTrip(tripId: TripId): Trip?
     fun validateIsValidTrip(tripId: TripId)
+    fun getTrips(userId: UserId, progress: Progress): List<Trip>
 }

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TripGateway.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/TripGateway.kt
@@ -5,6 +5,7 @@ import org.doorip.domain.AlreadyExistingParticipantException
 import org.doorip.domain.ExceedMaximumParticipantException
 import org.doorip.domain.TripNotFoundException
 import org.doorip.domain.UserNotFoundException
+import org.doorip.domain.trip.Progress
 import org.doorip.domain.trip.PropensityTag
 import org.doorip.domain.trip.Trip
 import org.doorip.domain.trip.TripId
@@ -91,6 +92,20 @@ internal class TripGateway(
         if (participants.size >= MAXIMUM_PARTICIPANT) {
             throw ExceedMaximumParticipantException
         }
+    }
+
+    override fun getTrips(userId: UserId, progress: Progress): List<Trip> {
+        val trips = when (progress) {
+            Progress.INCOMPLETE -> {
+                tripJpaRepository.findIncompleteTrips(userId.value, LocalDate.now())
+            }
+
+            Progress.COMPLETE -> {
+                tripJpaRepository.findCompleteTrips(userId.value, LocalDate.now())
+            }
+        }
+
+        return trips.map { it.toDomain() }
     }
 
     private fun generateCode(): String {

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/entity/AllocatorJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/entity/AllocatorJpaEntity.kt
@@ -9,10 +9,11 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.doorip.gateway.rdb.BaseJpaEntity
 
 @Table(name = "allocator")
 @Entity
-internal class AllocatorJpaEntity {
+internal class AllocatorJpaEntity : BaseJpaEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "allocator_id", columnDefinition = "bigint", nullable = false)

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/entity/ParticipantJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/entity/ParticipantJpaEntity.kt
@@ -13,13 +13,14 @@ import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.doorip.domain.trip.Participant
 import org.doorip.domain.trip.ParticipantId
+import org.doorip.gateway.rdb.BaseJpaEntity
 import org.doorip.gateway.rdb.user.entity.UserJpaEntity
 import org.hibernate.annotations.Cascade
 import org.hibernate.annotations.CascadeType
 
 @Table(name = "participant")
 @Entity
-internal class ParticipantJpaEntity {
+internal class ParticipantJpaEntity : BaseJpaEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "participant_id", columnDefinition = "bigint", nullable = false)

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/entity/TodoJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/entity/TodoJpaEntity.kt
@@ -15,12 +15,13 @@ import jakarta.persistence.Table
 import java.time.LocalDate
 import org.doorip.domain.trip.TodoStatus
 import org.doorip.domain.trip.TodoType
+import org.doorip.gateway.rdb.BaseJpaEntity
 import org.hibernate.annotations.Cascade
 import org.hibernate.annotations.CascadeType
 
 @Table(name = "todo")
 @Entity
-internal class TodoJpaEntity {
+internal class TodoJpaEntity : BaseJpaEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "todo_id", columnDefinition = "bigint", nullable = false)

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/entity/TripJpaEntity.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/entity/TripJpaEntity.kt
@@ -10,12 +10,13 @@ import jakarta.persistence.Table
 import java.time.LocalDate
 import org.doorip.domain.trip.Trip
 import org.doorip.domain.trip.TripId
+import org.doorip.gateway.rdb.BaseJpaEntity
 import org.hibernate.annotations.Cascade
 import org.hibernate.annotations.CascadeType
 
 @Table(name = "trip")
 @Entity
-internal class TripJpaEntity {
+internal class TripJpaEntity : BaseJpaEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "trip_id", columnDefinition = "bigint", nullable = false)
@@ -73,6 +74,5 @@ internal fun TripJpaEntity.toDomain(): Trip {
         title = this.title,
         startAt = this.startDate,
         endAt = this.endDate,
-        participants = participants.map { it.toDomain() },
     )
 }

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/repository/TripJpaRepository.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/repository/TripJpaRepository.kt
@@ -13,12 +13,9 @@ internal interface TripJpaRepository : JpaRepository<TripJpaEntity, Long> {
     @Query(
         "select t " +
             "from TripJpaEntity t " +
-            "join ParticipantJpaEntity p " +
-            "on p.trip = t " +
-            "join UserJpaEntity u " +
-            "on p.user = u " +
-            "where u.id = :userId " +
-            "and datediff(t.endDate, :now) >= 0 " +
+            "join ParticipantJpaEntity p on p.trip = t " +
+            "join UserJpaEntity u on p.user = u " +
+            "where u.id = :userId and t.endDate >= :now " +
             "order by datediff(t.startDate, :now), t.createdDate",
     )
     fun findIncompleteTrips(@Param("userId") userId: Long, @Param("now") now: LocalDate): List<TripJpaEntity>
@@ -26,12 +23,9 @@ internal interface TripJpaRepository : JpaRepository<TripJpaEntity, Long> {
     @Query(
         "select t " +
             "from TripJpaEntity t " +
-            "join ParticipantJpaEntity p " +
-            "on p.trip = t " +
-            "join UserJpaEntity u " +
-            "on p.user = u " +
-            "where u.id = :userId " +
-            "and datediff(t.endDate, :now) < 0 " +
+            "join ParticipantJpaEntity p on p.trip = t " +
+            "join UserJpaEntity u on p.user = u " +
+            "where u.id = :userId and t.endDate < :now " +
             "order by datediff(t.startDate, :now), t.createdDate",
     )
     fun findCompleteTrips(@Param("userId") userId: Long, @Param("now") now: LocalDate): List<TripJpaEntity>

--- a/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/repository/TripJpaRepository.kt
+++ b/gateway/rdb/src/main/kotlin/org/doorip/gateway/rdb/trip/repository/TripJpaRepository.kt
@@ -1,9 +1,38 @@
 package org.doorip.gateway.rdb.trip.repository
 
+import java.time.LocalDate
 import org.doorip.gateway.rdb.trip.entity.TripJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 internal interface TripJpaRepository : JpaRepository<TripJpaEntity, Long> {
     fun existsByCode(code: String): Boolean
     fun findByCode(code: String): TripJpaEntity?
+
+    @Query(
+        "select t " +
+            "from TripJpaEntity t " +
+            "join ParticipantJpaEntity p " +
+            "on p.trip = t " +
+            "join UserJpaEntity u " +
+            "on p.user = u " +
+            "where u.id = :userId " +
+            "and datediff(t.endDate, :now) >= 0 " +
+            "order by datediff(t.startDate, :now), t.createdDate",
+    )
+    fun findIncompleteTrips(@Param("userId") userId: Long, @Param("now") now: LocalDate): List<TripJpaEntity>
+
+    @Query(
+        "select t " +
+            "from TripJpaEntity t " +
+            "join ParticipantJpaEntity p " +
+            "on p.trip = t " +
+            "join UserJpaEntity u " +
+            "on p.user = u " +
+            "where u.id = :userId " +
+            "and datediff(t.endDate, :now) < 0 " +
+            "order by datediff(t.startDate, :now), t.createdDate",
+    )
+    fun findCompleteTrips(@Param("userId") userId: Long, @Param("now") now: LocalDate): List<TripJpaEntity>
 }

--- a/presentation/api/src/main/kotlin/org/doorip/api/trip/TripController.kt
+++ b/presentation/api/src/main/kotlin/org/doorip/api/trip/TripController.kt
@@ -5,23 +5,30 @@ import org.doorip.api.trip.dto.TripCreateRequest
 import org.doorip.api.trip.dto.TripCreateResponse
 import org.doorip.api.trip.dto.TripEntryRequest
 import org.doorip.api.trip.dto.TripEntryResponse
+import org.doorip.api.trip.dto.TripGetsResponse
+import org.doorip.api.trip.dto.TripResponse
 import org.doorip.api.trip.dto.TripVerifyInvitationCodeRequest
-import org.doorip.api.trip.dto.TripVerifyInvitationCodeResponse
+import org.doorip.api.trip.dto.toCreateResponse
 import org.doorip.api.trip.dto.toPropensityTag
 import org.doorip.api.trip.dto.toResponse
-import org.doorip.api.trip.dto.toVerifyResponse
 import org.doorip.core.trip.TripUseCase
+import org.doorip.core.user.ProfileUseCase
+import org.doorip.domain.InvalidRequestValueException
+import org.doorip.domain.trip.Progress
 import org.doorip.domain.trip.TripId
 import org.doorip.presentation.support.auth.AuthenticatedUser
 import org.doorip.presentation.support.auth.NeedAuthentication
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 
 @Controller
 class TripController(
+    private val profileUseCase: ProfileUseCase,
     private val tripUseCase: TripUseCase,
 ) {
 
@@ -37,7 +44,7 @@ class TripController(
             startAt = request.startDate,
             endAt = request.endDate,
             styles = request.toPropensityTag(),
-        ).toResponse()
+        ).toCreateResponse()
 
         return ApiResponse.created(response)
     }
@@ -46,9 +53,9 @@ class TripController(
     @PostMapping("/api/trips/verify")
     fun verifyInvitationCode(
         @RequestBody request: TripVerifyInvitationCodeRequest,
-    ): ResponseEntity<ApiResponse<TripVerifyInvitationCodeResponse>> {
+    ): ResponseEntity<ApiResponse<TripResponse>> {
         val response = tripUseCase.verifyInvitationCode(request.code)
-            .toVerifyResponse()
+            .toResponse()
 
         return ApiResponse.ok(response)
     }
@@ -67,5 +74,25 @@ class TripController(
         )
 
         return ApiResponse.ok(TripEntryResponse(tripId))
+    }
+
+    @NeedAuthentication
+    @GetMapping("/api/trips")
+    fun getTrips(
+        authenticatedUser: AuthenticatedUser,
+        @RequestParam(value = "progress") progress: String,
+    ): ResponseEntity<ApiResponse<TripGetsResponse>> {
+        val user = profileUseCase.getProfile(authenticatedUser.userId)
+
+        val enumProgress = Progress.getProgress(progress) ?: throw InvalidRequestValueException
+
+        val trips = tripUseCase.getTrips(authenticatedUser.userId, enumProgress)
+
+        val response = TripGetsResponse(
+            name = user.name,
+            trips = trips.map { it.toResponse() },
+        )
+
+        return ApiResponse.ok(response)
     }
 }

--- a/presentation/api/src/main/kotlin/org/doorip/api/trip/dto/TripCreateResponse.kt
+++ b/presentation/api/src/main/kotlin/org/doorip/api/trip/dto/TripCreateResponse.kt
@@ -16,7 +16,7 @@ data class TripCreateResponse(
     val day: Int,
 )
 
-fun Trip.toResponse(): TripCreateResponse = TripCreateResponse(
+fun Trip.toCreateResponse(): TripCreateResponse = TripCreateResponse(
     tripId = id.value,
     title = title,
     startDate = startAt,

--- a/presentation/api/src/main/kotlin/org/doorip/api/trip/dto/TripGetsResponse.kt
+++ b/presentation/api/src/main/kotlin/org/doorip/api/trip/dto/TripGetsResponse.kt
@@ -1,0 +1,6 @@
+package org.doorip.api.trip.dto
+
+data class TripGetsResponse(
+    val name: String,
+    val trips: List<TripResponse>,
+)

--- a/presentation/api/src/main/kotlin/org/doorip/api/trip/dto/TripResponse.kt
+++ b/presentation/api/src/main/kotlin/org/doorip/api/trip/dto/TripResponse.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import org.doorip.domain.trip.Trip
 
-data class TripVerifyInvitationCodeResponse(
+data class TripResponse(
     val tripId: Long,
     val title: String,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
@@ -15,7 +15,7 @@ data class TripVerifyInvitationCodeResponse(
     val day: Int,
 )
 
-fun Trip.toVerifyResponse(): TripVerifyInvitationCodeResponse = TripVerifyInvitationCodeResponse(
+fun Trip.toResponse(): TripResponse = TripResponse(
     tripId = id.value,
     title = title,
     startDate = startAt,


### PR DESCRIPTION
### Related Issue ✔
close #26 

### Description ✔
여행 대시보드 전체 조회 쿼리 실행 분석 및 성능 최적화
https://velog.io/@joydev/doorip-renewal-%EC%97%AC%ED%96%89-%EB%8C%80%EC%8B%9C%EB%B3%B4%EB%93%9C-%EC%A0%84%EC%B2%B4-%EC%A1%B0%ED%9A%8C-API-%EC%BF%BC%EB%A6%AC-%EC%8B%A4%ED%96%89-%EA%B3%84%ED%9A%8D-%EB%B6%84%EC%84%9D-%EB%B0%8F-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 사용자 진행 상태(미완료/완료)별로 트립 목록을 조회할 수 있는 필터링 기능이 추가되었습니다.
  - 트립 생성 및 초대 코드 검증 후 결과를 전달하는 응답 형식이 개선되었습니다.
  - 트립 조회를 위한 새로운 응답 데이터 클래스 `TripGetsResponse`가 추가되었습니다.

- **리팩터**
  - 트립 정보에서 불필요한 참가자 데이터가 제거되어 응답이 간소화되었습니다.
  - 응답 변환 방식이 통일되어 서비스 일관성과 사용성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->